### PR TITLE
rescue should be "rescue Exception => e" in release_savepoint_with_callback to be consistent with activerecord

### DIFF
--- a/lib/after_commit/after_savepoint.rb
+++ b/lib/after_commit/after_savepoint.rb
@@ -52,7 +52,7 @@ module AfterCommit
             trigger_after_commit_on_save_callbacks
             trigger_after_commit_on_update_callbacks
             trigger_after_commit_on_destroy_callbacks
-          rescue
+          rescue Exception => e
             unless committed
               decrement_transaction_pointer
               rollback_to_savepoint


### PR DESCRIPTION
I've only experienced this with activerecord 2.3.11, so perhaps it's only recently been introduced.

The ol' rescue only catches StandardError and children issue.  Unfortunately, the begin/rescue around active record transactions explicity catches Exception descendent classes, which means an exception not descending from StandardError (i.e. the ones thrown by mocha) will create an inconsistency between after_callback and activerecord.
