### PR TITLE
Fix: alias_method_chain not being made for transaction_with_callback

### DIFF
--- a/lib/after_commit/connection_adapters.rb
+++ b/lib/after_commit/connection_adapters.rb
@@ -3,7 +3,7 @@ module AfterCommit
     def self.included(base)
       base.class_eval do
 
-        if respond_to?(:transaction)
+        if method_defined?(:transaction)
           def transaction_with_callback(*args, &block)
             # @disable_rollback is set to false at the start of the
             # outermost call to #transaction.  After committing, it is
@@ -17,7 +17,7 @@ module AfterCommit
           end
           alias_method_chain :transaction, :callback
 
-        elsif respond_to?(:begin_db_transaction)
+        elsif method_defined?(:begin_db_transaction)
           def begin_db_transaction_with_callback(*args, &block)
             # @disable_rollback is set to false at the start of the
             # outermost call to #transaction.  After committing, it is


### PR DESCRIPTION
replaced respond_to? by method_defined? :

ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.method_defined? 'begin_db_transaction' => true 
ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.respond_to? 'begin_db_transaction' => false

My specs were failing due to non-ending transactions when I use thinking-sphinx. Then found this bug in after_commit.
