### PR TITLE
fix several issues related to leaking memory

### DIFF
--- a/lib/after_commit.rb
+++ b/lib/after_commit.rb
@@ -52,8 +52,7 @@ module AfterCommit
       :committed_records_on_save,
       :committed_records_on_destroy
     ].each do |collection|
-      Thread.current[collection]                        ||= {}
-      Thread.current[collection][connection.old_transaction_key] = []
+      Thread.current[collection] && Thread.current[collection].delete(connection.old_transaction_key)
     end
   end
   
@@ -68,7 +67,7 @@ module AfterCommit
   
   def self.collection(collection, connection)
     Thread.current[collection] ||= {}
-    Thread.current[collection][connection.old_transaction_key] ||= []
+    Thread.current[collection][connection.old_transaction_key] || []
   end
 end
 

--- a/lib/after_commit/connection_adapters.rb
+++ b/lib/after_commit/connection_adapters.rb
@@ -39,8 +39,8 @@ module AfterCommit
         # callback fired.
         def commit_db_transaction_with_callback
           increment_transaction_pointer
-          result    = nil
           begin
+            result = nil
             trigger_before_commit_callbacks
             trigger_before_commit_on_create_callbacks
             trigger_before_commit_on_update_callbacks
@@ -56,19 +56,9 @@ module AfterCommit
             trigger_after_commit_on_save_callbacks
             trigger_after_commit_on_destroy_callbacks
             result
-          rescue
-            # Need to decrement the transaction pointer before calling
-            # rollback... to ensure it is not incremented twice
-            unless @disable_rollback
-              decrement_transaction_pointer
-              @already_decremented = true
-            end
-            
-            # We still want to raise the exception.
-            raise
           ensure
             AfterCommit.cleanup(self)
-            decrement_transaction_pointer unless @already_decremented
+            decrement_transaction_pointer
           end
         end
         alias_method_chain :commit_db_transaction, :callback
@@ -89,7 +79,6 @@ module AfterCommit
             AfterCommit.cleanup(self)
             decrement_transaction_pointer
           end
-          decrement_transaction_pointer
         end
         alias_method_chain :rollback_db_transaction, :callback
         

--- a/test/after_commit_test.rb
+++ b/test/after_commit_test.rb
@@ -104,6 +104,21 @@ class TrackCountRecord < ActiveRecord::Base
 end
 
 class AfterCommitTest < Test::Unit::TestCase
+  def teardown
+    # always ensure that we've returned the transaction_pointer to zero
+    assert_equal(0, ActiveRecord::Base.connection.send(:transaction_pointer))
+    [
+      :committed_records,
+      :committed_records_on_create,
+      :committed_records_on_update,
+      :committed_records_on_save,
+      :committed_records_on_destroy
+    ].each do |collection|
+      # make sure we've cleaned up transaction-specific data properly
+      assert_equal({}, Thread.current[collection])
+    end
+  end
+
   def test_before_commit_on_create_is_called
     assert_equal true, MockRecord.create!.before_commit_on_create_called
   end


### PR DESCRIPTION
- remove duplicate decrement on the transaction_pointer during rollback
- remove unnecessary code to handle decrementing the transaction_pointer prior to rollback which caused transactions following the first rollback to fail to decrement the transaction_pointer
- change cleanup() unset the collection instead of reinitializing it to an empty array, so we don't keep numerous empty arrays in memory if the transaction pointer gets off
- add test assertions to ensure that the transaction pointer is always returned to zero and the transaction-specific in-memory objects have been cleared at the end of each test
