### PR TITLE
Rollback transactions in after_commit blocks

### DIFF
--- a/after_commit.gemspec
+++ b/after_commit.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "after_commit"
-  s.version = "1.0.11"
+  s.version = "1.0.12.pp"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Nick Muerdter", "David Yip", "Pat Allan"]

--- a/lib/after_commit/connection_adapters.rb
+++ b/lib/after_commit/connection_adapters.rb
@@ -77,7 +77,13 @@ module AfterCommit
         # should recieve the after_commit callback, but do fire the after_rollback
         # callback for each record that failed to be committed.
         def rollback_db_transaction_with_callback
-          return if @disable_rollback
+          if @disable_rollback
+            # if rollback is called and @disable_rollback is true, then ActiveRecord is trying to
+            # rollback from an exception in an `after_commit` block. Only rollback once by checking
+            # to see if we are back at the top level `after_commit` transaction
+           rollback_db_transaction_without_callback if transaction_pointer == 0
+           return
+          end
           increment_transaction_pointer
           begin
             result = nil


### PR DESCRIPTION
If there is an exception in a transaction that occurs in after_commit block, we need to call `ROLLBACK` otherwise the connection will be unusable
